### PR TITLE
Ignore lombok's generated methods in coverage

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/osuCelebrity-parent/pom.xml
+++ b/osuCelebrity-parent/pom.xml
@@ -27,6 +27,18 @@
 			<url>http://repo.omkserver.nl/content/repositories/releases/</url>
 		</repository>
 	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>oss-snapshots</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</pluginRepository>
+	</pluginRepositories>
 	<build>
 		<plugins>
 			<plugin>
@@ -112,7 +124,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.5.201505241946</version>
+				<version>0.7.10-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>
@@ -173,7 +185,7 @@
 			<dependency>
 				<groupId>org.projectlombok</groupId>
 				<artifactId>lombok</artifactId>
-				<version>1.14.2</version>
+				<version>1.16.16</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.inject</groupId>


### PR DESCRIPTION
New versions of lombok and jacoco allow ignoring lombok's generated methods in coverage.
Unfortunately, JDO's generated methods remain.